### PR TITLE
Multilingual support

### DIFF
--- a/src/main/plugin/dcat-ap/duplicate-metadata.xsl
+++ b/src/main/plugin/dcat-ap/duplicate-metadata.xsl
@@ -41,11 +41,8 @@
       <dct:identifier>
         <xsl:value-of select="$resourceUUID"/>
       </dct:identifier>
-      <dct:title xml:lang="nl"/>
 
-      <xsl:apply-templates select="dct:title[position() > 1]"/>
-
-      <xsl:apply-templates select="*[name() != 'dct:identifier' and name() != 'dct:title']"/>
+      <xsl:apply-templates select="*[name() != 'dct:identifier']"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -373,7 +373,7 @@
         <xsl:for-each select="current-group()/skos:Concept">
           {
           "key": [
-          "<xsl:value-of select="gn-fn-index:json-escape(./@rdf:about)"/>"
+          "<xsl:value-of select="util:escapeForJson(./@rdf:about)"/>"
           ],
           "default": [
           "<xsl:value-of select="./skos:prefLabel[@xml:lang='nl']"/>"
@@ -393,9 +393,9 @@
         <xsl:for-each select="dcat:keyword">
           {
           <xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>,
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>,
           <xsl:value-of select="concat($doubleQuote, 'lang', gn-fn-index:lang-2char-to-3char(@xml:lang), $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
           }
           <xsl:if test="position() != last()">,</xsl:if>
         </xsl:for-each>
@@ -414,9 +414,9 @@
           <xsl:for-each select="dcat:keyword[normalize-space() != '']">
             {
             <xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>,
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>,
             <xsl:value-of select="concat($doubleQuote, 'lang', gn-fn-index:lang-2char-to-3char(@xml:lang), $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
             }
             <xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
@@ -438,12 +438,12 @@
               <xsl:variable name="thesaurusField" select="concat('th_',$key)"/>
               <xsl:variable name="thesaurusTitle" select="util:getThesaurusTitleByName($thesaurusId)"/>
               "<xsl:value-of select="$thesaurusField"/>": {
-              "id": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusId)"/>",
+              "id": "<xsl:value-of select="util:escapeForJson($thesaurusId)"/>",
               <xsl:if test="$thesaurusTitle != ''">
-                "title": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusTitle)"/>",
+                "title": "<xsl:value-of select="util:escapeForJson($thesaurusTitle)"/>",
               </xsl:if>
               "theme": "theme",
-              "link": "<xsl:value-of select="gn-fn-index:json-escape((current-group()/skos:Concept/skos:inScheme/@rdf:resource)[1])"/>",
+              "link": "<xsl:value-of select="util:escapeForJson((current-group()/skos:Concept/skos:inScheme/@rdf:resource)[1])"/>",
               "keywords": [
               <xsl:for-each select="current-group()/skos:Concept">
                 <xsl:value-of select="gn-fn-index:add-multilingual-field-dcat-ap('keyword', ., $allLanguages)/text()"/>
@@ -597,8 +597,8 @@
         "organisationObject": <xsl:value-of select="$organisationObject" />,
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
-      "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
-      "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>"
+      "email":"<xsl:value-of select="util:escapeForJson($email[1])"/>",
+      "phone":"<xsl:value-of select="util:escapeForJson($phone[1])"/>"
       }
     </xsl:element>
 
@@ -638,11 +638,11 @@
         "organisationObject": <xsl:value-of select="$organisationObject" />,
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
-      "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
+      "email":"<xsl:value-of select="util:escapeForJson($email[1])"/>",
       "website":"<xsl:value-of select="$website"/>",
-      "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
-      "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",
-      "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      "individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>",
+      "phone":"<xsl:value-of select="util:escapeForJson($phone[1])"/>",
+      "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
       }
     </xsl:element>
   </xsl:template>
@@ -689,7 +689,7 @@
 
     <xsl:if test="normalize-space($topLevelProtocol) != ''">
       <topLevelProtocol>
-        <xsl:value-of select="gn-fn-index:json-escape($topLevelProtocol)"/>
+        <xsl:value-of select="util:escapeForJson($topLevelProtocol)"/>
       </topLevelProtocol>
     </xsl:if>
   </xsl:template>
@@ -885,26 +885,26 @@
         <xsl:if test="position() = 1">
           <value>
             <xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                    $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                    $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
           </value>
           <xsl:for-each select="$elements/*[name() = $lookupElement]">
-            <xsl:if test="gn-fn-index:json-escape(.) != ''">
+            <xsl:if test="util:escapeForJson(.) != ''">
               <value>
                 <xsl:value-of select="concat($doubleQuote, 'lang', gn-fn-index:lang-2char-to-3char(@xml:lang), $doubleQuote, ':',
-                                        $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                        $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
               </value>
             </xsl:if>
           </xsl:for-each>
           <xsl:if test="$url != ''">
             <value>
               <xsl:value-of select="concat($doubleQuote, 'link', $doubleQuote, ':', $doubleQuote,
-                                      gn-fn-index:json-escape($url), $doubleQuote)"/>
+                                      util:escapeForJson($url), $doubleQuote)"/>
             </value>
           </xsl:if>
           <xsl:if test="$withKey and $url != ''">
             <value>
               <xsl:value-of select="concat($doubleQuote, 'key', $doubleQuote, ':', $doubleQuote,
-                                      gn-fn-index:json-escape($url), $doubleQuote)"/>
+                                      util:escapeForJson($url), $doubleQuote)"/>
             </value>
           </xsl:if>
         </xsl:if>
@@ -933,7 +933,7 @@
       <xsl:variable name="textObject">
         <value>
           <xsl:value-of select="concat($doubleQuote, 'link', $doubleQuote, ':', $doubleQuote,
-                                      gn-fn-index:json-escape($url), $doubleQuote)"/>
+                                      util:escapeForJson($url), $doubleQuote)"/>
         </value>
       </xsl:variable>
 

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -436,7 +436,7 @@
           <xsl:if test="normalize-space($key) != ''">
             <value>
               <xsl:variable name="thesaurusField" select="concat('th_',$key)"/>
-              <xsl:variable name="thesaurusTitle" select="util:getThesaurusTitleByName($thesaurusId)"/>
+              <xsl:variable name="thesaurusTitle" select="util:getThesaurusTitleByKey($thesaurusId)"/>
               "<xsl:value-of select="$thesaurusField"/>": {
               "id": "<xsl:value-of select="util:escapeForJson($thesaurusId)"/>",
               <xsl:if test="$thesaurusTitle != ''">

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -589,9 +589,13 @@
     <xsl:copy-of select="gn-fn-index:add-multilingual-field-dcat-ap(concat('Org', $fieldSuffix), foaf:Agent, $allLanguages, false(), false(), 'foaf:name')"/>
     <xsl:copy-of select="gn-fn-index:add-multilingual-field-dcat-ap(concat(replace($role, '[^a-zA-Z0-9-]', ''), 'Org', $fieldSuffix), foaf:Agent, $allLanguages, false(), false(), 'foaf:name')"/>
 
+    <xsl:variable name="organisationObject" select="gn-fn-index:add-multilingual-field-dcat-ap('organisationObject', foaf:Agent, $allLanguages, false(), false(), 'foaf:name')" />
+
     <xsl:element name="contact{$fieldSuffix}">
       <xsl:attribute name="type" select="'object'"/>{
-      "organisation":"<xsl:value-of select="gn-fn-index:json-escape($organisationName)"/>",
+      <xsl:if test="$organisationObject">
+        "organisationObject": <xsl:value-of select="$organisationObject" />,
+      </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
       "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>"
@@ -626,9 +630,13 @@
     <xsl:copy-of select="gn-fn-index:add-multilingual-field-dcat-ap(concat('Org', $fieldSuffix), vcard:Organization, $allLanguages, false(), false(), 'vcard:organization-name')"/>
     <xsl:copy-of select="gn-fn-index:add-multilingual-field-dcat-ap(concat(replace($role, '[^a-zA-Z0-9-]', ''), 'Org', $fieldSuffix), vcard:Organization, $allLanguages, false(), false(), 'vcard:organization-name')"/>
 
+    <xsl:variable name="organisationObject" select="gn-fn-index:add-multilingual-field-dcat-ap('organisationObject', vcard:Organization, $allLanguages, false(), false(), 'vcard:organization-name')" />
+
     <xsl:element name="contact{$fieldSuffix}">
       <xsl:attribute name="type" select="'object'"/>{
-      "organisation":"<xsl:value-of select="gn-fn-index:json-escape($organisationName)"/>",
+      <xsl:if test="$organisationObject">
+        "organisationObject": <xsl:value-of select="$organisationObject" />,
+      </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
       "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
       "website":"<xsl:value-of select="$website"/>",

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -320,7 +320,7 @@
   </xsl:template>
 
   <xsl:template mode="index-keyword" match="dcat:Dataset|dcat:DataService">
-    <xsl:variable name="keywords" select="dcat:keyword[normalize-space() != '']|(dct:subject|dcat:theme|mdcat:statuut|mdcat:MAGDA-categorie)[skos:Concept/skos:prefLabel[normalize-space() != '']]"/>
+    <xsl:variable name="keywords" select="dcat:keyword[normalize-space() != '']|(dct:subject|dcat:theme|mdcat:statuut|mdcat:MAGDA-categorie)[skos:Concept/skos:prefLabel[normalize-space() != '']]/skos:Concept/skos:prefLabel"/>
     <tagNumber>
       <xsl:value-of select="count($keywords)"/>
     </tagNumber>
@@ -333,8 +333,8 @@
           </xsl:when>
           <xsl:otherwise>
             {
-            <xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':', $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>,
-            <xsl:value-of select="concat($doubleQuote, 'lang', gn-fn-index:lang-2char-to-3char(@xml:lang), $doubleQuote, ':', $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+            <xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':', $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>,
+            <xsl:value-of select="concat($doubleQuote, 'lang', gn-fn-index:lang-2char-to-3char(@xml:lang), $doubleQuote, ':', $doubleQuote,  util:escapeForJson(.), $doubleQuote)"/>
             }
           </xsl:otherwise>
         </xsl:choose>
@@ -953,7 +953,7 @@
         <xsl:value-of select="'fra'"/>
       </xsl:when>
       <xsl:when test="$langUri = 'http://publications.europa.eu/resource/authority/language/ENG'">
-        <xsl:value-of select="'end'"/>
+        <xsl:value-of select="'eng'"/>
       </xsl:when>
       <xsl:when test="$langUri = 'http://publications.europa.eu/resource/authority/language/DEU'">
         <xsl:value-of select="'ger'"/>

--- a/src/main/plugin/dcat-ap/index-fields/index.xsl
+++ b/src/main/plugin/dcat-ap/index-fields/index.xsl
@@ -58,22 +58,22 @@
                 select="//rdf:RDF"/>
 
   <xsl:variable name="allLanguages">
-    <xsl:variable name="listOfLanguages">
+    <xsl:variable name="listOfLanguage">
       <xsl:call-template name="get-dcat-ap-other-languages"/>
     </xsl:variable>
-
-    <xsl:for-each select="$listOfLanguages/*">
-      <lang value="{@code}">
-        <xsl:if test="position() = 1">
-          <xsl:attribute name="id"
-                         select="'default'"/>
+    <xsl:for-each select="$listOfLanguage/lang">
+      <lang value="{@code}" code="{@id}">
+        <xsl:if test="@default">
+          <xsl:attribute name="id" select="'default'"/>
         </xsl:if>
       </lang>
     </xsl:for-each>
   </xsl:variable>
 
-  <xsl:variable name="defaultMainLanguage3Char" select="'dut'"/>
-  <xsl:variable name="defaultMainLanguage2Char" select="'nl'"/>
+  <xsl:variable name="defaultMainLanguage3Char" select="$allLanguages/lang[@id]/@value"/>
+
+  <xsl:variable name="defaultMainLanguage2Char" select="$allLanguages/lang[@id]/@code"/>
+
   <xsl:variable name="editorConfig"
                 select="document('../layout/config-editor.xml')"/>
 
@@ -721,21 +721,21 @@
           <xsl:when test="count(dct:title)= 1">
             "<xsl:value-of select="normalize-space(dct:title)"/>"
           </xsl:when>
-          <xsl:when test="count(dct:title)>1">
+          <!--<xsl:when test="count(dct:title)>1">
             <xsl:for-each select="dct:title">
               {
               <xsl:value-of select="normalize-space(.)"/>
               }
               <xsl:if test="position() != last()">,</xsl:if>
             </xsl:for-each>
-          </xsl:when>
+          </xsl:when>-->
           <xsl:otherwise>
             ""
           </xsl:otherwise>
         </xsl:choose>
         ,
         "description":
-        "<xsl:value-of select="normalize-space(dct:description)"/>",
+        "<xsl:value-of select="util:escapeForJson(normalize-space(dct:description[1]))"/>",
         "function":"",
         "applicationProfile":"",
         "group":0

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -423,21 +423,40 @@
       <name>dct:description</name>
     </expanded>
     <exclude>
+      <name>adms:identifier</name>
       <name>dcat:spatialResolutionInMeters</name>
       <name>dcat:temporalResolution</name>
       <name>dcat:startDate</name>
       <name>dcat:endDate</name>
+      <name>dcat:accessURL</name>
+      <name>dcat:downloadURL</name>
+      <name>dcat:byteSize</name>
+      <name>dcat:compressFormat</name>
+      <name>dcat:packageFormat</name>
       <name>dct:identifier</name>
       <name>dct:language</name>
+      <name>dct:format</name>
       <name>dct:modified</name>
       <name>dct:issued</name>
+      <name>dct:hasPart</name>
+      <name>dct:isPartOf</name>
+      <name>dct:relation</name>
+      <name>dct:isReferencedBy</name>
+      <name>dct:hasVersion</name>
+      <name>dct:isVersionOf</name>
+      <name>dct:source</name>
+      <name>dct:spatial</name>
+      <name>dct:accrualPeriodicity</name>
       <name>foaf:Document</name>
+      <name>foaf:primaryTopic</name>
       <name>owl:versionInfo</name>
       <name>prov:atTime</name>
+      <name>spdx:checksum</name>
       <name>vcard:hasEmail</name>
       <name>vcard:hasTelephone</name>
       <name>vcard:postal-code</name>
       <name>vcard:fn</name>
+      <name>skos:inScheme</name>
     </exclude>
   </multilingualFields>
 
@@ -483,9 +502,7 @@
           </action>
 
 
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description"
-                 or="description"
-                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description"/>
 
           <action type="add" or="description" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description)=0">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -630,8 +630,8 @@
                 <dct:conformsTo>
                   <dct:Standard>
                     <dct:identifier/>
-                    <dct:title xml:lang="nl"/>
-                    <dct:description xml:lang="nl"/>
+                    <dct:title xml:lang=""/>
+                    <dct:description xml:lang=""/>
                   </dct:Standard>
                 </dct:conformsTo>
               </snippet>
@@ -663,8 +663,8 @@
                 <snippet>
                   <dct:rights>
                     <dct:RightsStatement>
-                      <dct:title xml:lang="nl"/>
-                      <dct:description xml:lang="nl"/>
+                      <dct:title xml:lang=""/>
+                      <dct:description xml:lang=""/>
                     </dct:RightsStatement>
                   </dct:rights>
                 </snippet>
@@ -682,8 +682,8 @@
               <snippet>
                 <dcat:distribution>
                   <dcat:Distribution>
-                    <dct:title xml:lang="nl"/>
-                    <dct:description xml:lang="nl"/>
+                    <dct:title xml:lang=""/>
+                    <dct:description xml:lang=""/>
                     <dcat:accessURL rdf:resource=""/>
                   </dcat:Distribution>
                 </dcat:distribution>
@@ -700,7 +700,7 @@
                   if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:title) = 0">
             <template>
               <snippet>
-                <dct:title xml:lang="nl"/>
+                <dct:title xml:lang=""/>
               </snippet>
             </template>
           </action>
@@ -710,7 +710,7 @@
                   if="count(rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:description) = 0">
             <template>
               <snippet>
-                <dct:description xml:lang="nl"/>
+                <dct:description xml:lang=""/>
               </snippet>
             </template>
           </action>
@@ -720,7 +720,7 @@
               <snippet>
                 <dct:publisher>
                   <foaf:Agent>
-                    <foaf:name xml:lang="nl"/>
+                    <foaf:name xml:lang=""/>
                   </foaf:Agent>
                 </dct:publisher>
               </snippet>
@@ -831,8 +831,8 @@
               <snippet>
                 <dct:rights>
                   <dct:RightsStatement>
-                    <dct:title xml:lang="nl"/>
-                    <dct:description xml:lang="nl"/>
+                    <dct:title xml:lang=""/>
+                    <dct:description xml:lang=""/>
                   </dct:RightsStatement>
                 </dct:rights>
               </snippet>
@@ -1021,8 +1021,8 @@
               <snippet>
                 <dcat:distribution>
                   <dcat:Distribution>
-                    <dct:title xml:lang="nl"/>
-                    <dct:description xml:lang="nl"/>
+                    <dct:title xml:lang=""/>
+                    <dct:description xml:lang=""/>
                     <dcat:accessURL rdf:resource=""/>
                     <dcat:downloadURL rdf:resource=""/>
                     <dct:format/>
@@ -1189,8 +1189,6 @@
               <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
                 <skos:prefLabel xml:lang="nl">Werk in het publiek domein</skos:prefLabel>
                 <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
-                <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
-                <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
                 <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0" />
               </skos:Concept>
             </dct:type>
@@ -1205,15 +1203,12 @@
           <dct:LicenseDocument rdf:about="">
             <dct:type>
               <skos:Concept>
-                <skos:prefLabel xml:lang="nl"/>
-                <skos:prefLabel xml:lang="en"/>
-                <skos:prefLabel xml:lang="fr"/>
-                <skos:prefLabel xml:lang="de"/>
+                <skos:prefLabel xml:lang=""/>
                 <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
               </skos:Concept>
             </dct:type>
-            <dct:title xml:lang="nl"/>
-            <dct:description xml:lang="nl"/>
+            <dct:title xml:lang=""/>
+            <dct:description xml:lang=""/>
             <!--dct:identifier/-->
           </dct:LicenseDocument>
         </dct:license>
@@ -1674,8 +1669,8 @@
         <dct:conformsTo>
           <dct:Standard xmlns:dct="http://purl.org/dc/terms/">
             <dct:identifier/>
-            <dct:title xml:lang="nl"/>
-            <dct:description xml:lang="nl" />
+            <dct:title xml:lang=""/>
+            <dct:description xml:lang="" />
           </dct:Standard>
         </dct:conformsTo>
       </snippet>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -363,6 +363,14 @@
 
   <!-- Complex fields. -->
   <fieldsWithFieldset>
+    <name>rdf:RDF</name>
+    <name>dcat:Catalog</name>
+    <name>dcat:Dataset</name>
+    <name>dcat:CatalogRecord</name>
+    <name>dcat:record</name>
+    <name>dcat:dataset</name>
+    <name>dcat:service</name>
+    <name>dct:language</name>
     <name>dcat:contactPoint</name>
     <name>vcard:Organization</name>
     <name>vcard:hasAddress</name>
@@ -399,8 +407,22 @@
   </fieldsWithFieldset>
 
   <multilingualFields>
+    <expanded>
+      <name>dct:title</name>
+      <name>dct:description</name>
+    </expanded>
     <exclude>
       <name>dct:identifier</name>
+      <name>dct:language</name>
+      <name>dct:modified</name>
+      <name>dct:issued</name>
+      <name>prov:atTime</name>
+      <name>dcat:startDate</name>
+      <name>dcat:endDate</name>
+      <name>vcard:hasEmail</name>
+      <name>foaf:Document</name>
+      <name>dcat:spatialResolutionInMeters</name>
+      <name>dcat:temporalResolution</name>
     </exclude>
   </multilingualFields>
 
@@ -1054,6 +1076,16 @@
         </section>
       </tab>
 
+    </view>
+
+    <view name="fromroot">
+      <sidePanel>
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
+        <directive data-gn-validation-report=""/>
+      </sidePanel>
+      <tab id="dcat.catalog-record">
+        <section xpath="/rdf:RDF"/>
+      </tab>
     </view>
 
     <view name="xml">

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -358,7 +358,6 @@
         max="1"
         labelKey="mdcat.addOntwikkelingstoestand"/>
     </for>
-
   </fields>
 
   <!-- Complex fields. -->
@@ -370,6 +369,11 @@
     <name>dcat:record</name>
     <name>dcat:dataset</name>
     <name>dcat:service</name>
+    <name>foaf:isPrimaryTopicOf</name>
+    <name>foaf:Organization</name>
+    <name>vcard:org</name>
+    <name>dcat:hadRole</name>
+    <name>dcat:Role</name>
     <name>dct:language</name>
     <name>dcat:contactPoint</name>
     <name>vcard:Organization</name>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -423,17 +423,21 @@
       <name>dct:description</name>
     </expanded>
     <exclude>
+      <name>dcat:spatialResolutionInMeters</name>
+      <name>dcat:temporalResolution</name>
+      <name>dcat:startDate</name>
+      <name>dcat:endDate</name>
       <name>dct:identifier</name>
       <name>dct:language</name>
       <name>dct:modified</name>
       <name>dct:issued</name>
-      <name>prov:atTime</name>
-      <name>dcat:startDate</name>
-      <name>dcat:endDate</name>
-      <name>vcard:hasEmail</name>
       <name>foaf:Document</name>
-      <name>dcat:spatialResolutionInMeters</name>
-      <name>dcat:temporalResolution</name>
+      <name>owl:versionInfo</name>
+      <name>prov:atTime</name>
+      <name>vcard:hasEmail</name>
+      <name>vcard:hasTelephone</name>
+      <name>vcard:postal-code</name>
+      <name>vcard:fn</name>
     </exclude>
   </multilingualFields>
 

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -71,6 +71,13 @@
         max="1"
         labelKey="dcat.addAccessRight"/>
     </for>
+    <for name="dct:language" xpath="dcat:CatalogRecord" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.language"
+        xpath="/dct:language"
+        max=""
+        labelKey="dcat.addLanguage"/>
+    </for>
     <for name="dct:language" xpath="dcat:Dataset" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.theme.language"
@@ -465,7 +472,7 @@
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title)=0">
             <template>
               <snippet>
-                <dct:title xml:lang="nl"/>
+                <dct:title xml:lang=""/>
               </snippet>
             </template>
           </action>
@@ -474,7 +481,7 @@
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description)=0">
             <template>
               <snippet>
-                <dct:description xml:lang="nl"/>
+                <dct:description xml:lang="fr">aa</dct:description>
               </snippet>
             </template>
           </action>
@@ -854,7 +861,9 @@
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:identifier"/>
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:modified"/>
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:issued"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:language"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:language"
+                 or="language"
+                 in="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord"/>
         </section>
         <section name="conformToInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:conformsTo/dct:Standard/dct:identifier"/>
@@ -1071,7 +1080,9 @@
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:identifier"/>
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:modified"/>
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:issued"/>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:language"/>
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:language"
+                 or="language"
+                 in="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord"/>
         </section>
         <section name="conformToInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:record/dcat:CatalogRecord/dct:conformsTo/dct:Standard/dct:identifier"/>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -468,6 +468,7 @@
            hideIfNotDisplayed="true">
         <section name="basicInformation">
           <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title"/>
+
           <action type="add" or="title" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:title)=0">
             <template>
@@ -476,28 +477,32 @@
               </snippet>
             </template>
           </action>
-          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description"/>
+
+
+          <field xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description"
+                 or="description"
+                 in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"/>
+
           <action type="add" or="description" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset"
                   if="count(rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:description)=0">
             <template>
               <snippet>
-                <dct:description xml:lang="fr">aa</dct:description>
+                <dct:description xml:lang=""></dct:description>
               </snippet>
             </template>
           </action>
+
           <section xpath="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dct:publisher"/>
+
           <action type="add" or="publisher" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
             <template>
               <snippet>
                 <dct:publisher>
                   <foaf:Agent>
-                    <foaf:name xml:lang="nl"/>
+                    <foaf:name xml:lang=""/>
                     <dct:type>
                       <skos:Concept>
-                        <skos:prefLabel xml:lang="nl"/>
-                        <skos:prefLabel xml:lang="en"/>
-                        <skos:prefLabel xml:lang="fr"/>
-                        <skos:prefLabel xml:lang="de"/>
+                        <skos:prefLabel xml:lang=""/>
                         <skos:inScheme rdf:resource="http://purl.org/adms/publishertype/1.0"/>
                       </skos:Concept>
                     </dct:type>

--- a/src/main/plugin/dcat-ap/layout/config-editor.xml
+++ b/src/main/plugin/dcat-ap/layout/config-editor.xml
@@ -428,8 +428,10 @@
       <name>dcat:temporalResolution</name>
       <name>dcat:startDate</name>
       <name>dcat:endDate</name>
+      <name>dcat:servesDataset</name>
       <name>dcat:accessURL</name>
       <name>dcat:downloadURL</name>
+      <name>dcat:endpointURL</name>
       <name>dcat:byteSize</name>
       <name>dcat:compressFormat</name>
       <name>dcat:packageFormat</name>

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-concepts.xsl
@@ -83,17 +83,8 @@
               </xsl:if>
             </xsl:for-each>
           </xsl:when>
-          <!-- Show prefLabel in nl language -->
-          <xsl:when test="../*[name() = $config/@name]//skos:prefLabel[@xml:lang = 'nl']">
-            <xsl:value-of select="string-join(../*[name() = $config/@name]//skos:prefLabel[@xml:lang = 'nl']/replace(text(), ',', ',,'), ',')"/>
-          </xsl:when>
-          <!-- Fallback on preflabel without any language -->
-          <xsl:when test="../*[name() = $config/@name]//skos:prefLabel[not(@xml:lang)]">
-            <xsl:value-of select="string-join(../*[name() = $config/@name]//skos:prefLabel[not(@xml:lang)]/replace(text(), ',', ',,'), ',')"/>
-          </xsl:when>
-          <!-- Fallback on first preflabel -->
-          <xsl:when test="../*[name() = $config/@name]//skos:prefLabel[not(@xml:lang)]">
-            <xsl:value-of select="string-join(../*[name() = $config/@name]//skos:prefLabel[not(@xml:lang)]/replace(text(), ',', ',,'), ',')"/>
+          <xsl:when test="../*[name() = $config/@name]//skos:prefLabel[1]">
+            <xsl:value-of select="string-join(../*[name() = $config/@name]//skos:prefLabel[1]/replace(text(), ',', ',,'), ',')"/>
           </xsl:when>
         </xsl:choose>
       </xsl:variable>
@@ -128,7 +119,12 @@
 
   <xsl:template name="GetThesaurusElementXpath">
     <xsl:param name="config" as="node()"/>
-    <xsl:variable name="resourcePath" select="concat('./dcat:Catalog', if ($isDcatService) then '/dcat:service/dcat:DataService' else '/dcat:dataset/dcat:Dataset')"/>
+    <xsl:variable name="resourcePath"
+                  select="concat('./dcat:Catalog',
+                                  if ($isDcatService) then '/dcat:service/dcat:DataService'
+                                  else if (ancestor::*[1]/name() = 'dcat:CatalogRecord') then '/dcat:record/dcat:CatalogRecord'
+                                  else '/dcat:dataset/dcat:Dataset')"/>
+
     <xsl:choose>
       <xsl:when test="starts-with($config/xpath, '/dcat:Distribution')">
         <xsl:value-of select="concat('(', $resourcePath, '/dcat:distribution)[dcat:Distribution/@rdf:about=''', ../@rdf:about ,''']', $config/xpath)"/>

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields-sds.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields-sds.xsl
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0"
-                exclude-result-prefixes="#all">
-
-</xsl:stylesheet>

--- a/src/main/plugin/dcat-ap/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout-custom-fields.xsl
@@ -45,7 +45,6 @@
     exclude-result-prefixes="#all">
 
   <xsl:include href="layout-custom-fields-concepts.xsl"/>
-  <xsl:include href="layout-custom-fields-sds.xsl"/>
   <xsl:include href="layout-custom-fields-date.xsl"/>
 
   <xsl:template mode="mode-dcat-ap" match="dct:spatial" priority="2000">

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -195,129 +195,238 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
-    <xsl:variable name="name" select="name(.)"/>
-    <xsl:variable name="ref" select="gn:element/@ref"/>
-    <xsl:variable name="labelConfig" as="node()" select="gn-fn-metadata:getLabel($schema, $name, $labels, name(..), '', gn-fn-metadata:getXPath(.))"/>
-    <xsl:variable name="helper" select="gn-fn-metadata:getHelper($labelConfig/helper, .)"/>
-    <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
-    <xsl:variable name="container" select="parent::node()/parent::node()"/>
 
-    <!-- Add view and edit template-->
-    <xsl:variable name="contextXpath" select="gn-fn-metadata:getXPath(.)"/>
-    <xsl:variable name="fieldNode" select="$editorConfig/editor/fields/for[@name = $name and @templateModeOnly and (not(@xpath) or @xpath = $contextXpath)]"/>
+    <!-- Unify language code to use 3 letter code -->
+    <xsl:variable name="elementLang">
+      <xsl:choose>
+        <xsl:when test="string-length(@xml:lang) = 3">
+          <xsl:value-of select="java:twoCharLangCode(@xml:lang)"/>
+        </xsl:when>
+        <xsl:when test="string-length(@xml:lang) = 2">
+          <xsl:value-of select="@xml:lang"/>
+        </xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
 
-    <xsl:variable name="isDisabled" select="
-          (name(.) = 'dct:identifier' and count(preceding-sibling::*[name(.) = 'dct:identifier']) = 0 and name(..) = ('dcat:Dataset', 'dcat:DataService')) or
-          (name(..) = 'dcat:Distribution' and name(.) = ('dct:identifier')) or
-          (name(..) = 'dcat:CatalogRecord') or
-          (name(../../..) = 'dcat:CatalogRecord' and name(..) = 'dct:Standard')"/>
+    <!-- Skip translations. update-fixed-info takes care of having
+    at least one element define in the main language. -->
+    <xsl:if test="not(@xml:lang) or $elementLang = $metadataLanguage">
 
-    <xsl:choose>
-      <xsl:when test="count($fieldNode/*)>0 and $fieldNode/@templateModeOnly and not($isDisabled)">
-        <xsl:variable name="del" select="'.'"/>
-        <xsl:variable name="template" select="$fieldNode/template"/>
-        <xsl:variable name="currentNode" select="." />
-        <xsl:variable name="readonly">
-          <xsl:choose>
-            <xsl:when test="$template/values/@readonlyIf">
-              <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
-                <xsl:with-param name="base" select="$currentNode"/>
-                <xsl:with-param name="in" select="concat('/', $template/values/@readonlyIf)"/>
-              </saxon:call-template>
-            </xsl:when>
-          </xsl:choose>
-        </xsl:variable>
+      <xsl:variable name="name" select="name(.)"/>
+      <xsl:variable name="ref" select="gn:element/@ref"/>
+      <xsl:variable name="labelConfig" as="node()" select="gn-fn-metadata:getLabel($schema, $name, $labels, name(..), '', gn-fn-metadata:getXPath(.))"/>
+      <xsl:variable name="helper" select="gn-fn-metadata:getHelper($labelConfig/helper, .)"/>
+      <xsl:variable name="added" select="parent::node()/parent::node()/@gn:addedObj"/>
+      <xsl:variable name="container" select="parent::node()/parent::node()"/>
 
-        <xsl:variable name="templateCombinedWithNode" as="node()">
-          <template>
-            <xsl:copy-of select="$template/values"/>
-            <snippet>
-              <xsl:apply-templates mode="gn-merge" select="$template/snippet/*|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet/*">
-                <xsl:with-param name="node-to-merge" select="$currentNode"/>
-              </xsl:apply-templates>
-            </snippet>
-          </template>
-        </xsl:variable>
 
-        <xsl:variable name="keyValues">
-          <xsl:call-template name="build-key-value-configuration">
-            <xsl:with-param name="template" select="$template"/>
-            <xsl:with-param name="currentNode" select="$currentNode"/>
-            <xsl:with-param name="readonly" select="$readonly"/>
+      <xsl:variable name="theElement"
+                    select="."/>
+
+      <xsl:variable name="attributes">
+        <!-- Create form for all existing attribute (not in gn namespace)
+        and all non existing attributes not already present for the
+        current element and its children (eg. @uom in gco:Distance).
+        A list of exception is defined in form-builder.xsl#render-for-field-for-attribute. -->
+        <xsl:apply-templates mode="render-for-field-for-attribute-dcat-ap"
+                             select="@*[name() != 'xml:lang']">
+          <xsl:with-param name="ref" select="gn:element/@ref"/>
+          <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates mode="render-for-field-for-attribute"
+                             select="gn:attribute[not(@name = parent::node()/@*/name())
+                                                  and not(@name = 'xml:lang')]">
+          <xsl:with-param name="ref" select="gn:element/@ref"/>
+          <xsl:with-param name="insertRef" select="$theElement/gn:element/@ref"/>
+        </xsl:apply-templates>
+      </xsl:variable>
+
+
+      <xsl:variable name="excluded"
+                    select="gn-fn-dcat-ap:isNotMultilingualField(., $editorConfig)"/>
+      <xsl:variable name="isMultilingualElement"
+                    select="$metadataIsMultilingual and $excluded = false()"/>
+      <xsl:variable name="isMultilingualElementExpanded"
+                    select="$isMultilingualElement and count($editorConfig/editor/multilingualFields/expanded[name = $name]) > 0"/>
+      <!--
+      If main language is eng.
+      Other language fre.
+
+      <dcat:keyword xml:lang="eng">Water</dcat:keyword>
+      <dcat:keyword xml:lang="fre">Eau</dcat:keyword>
+      <dcat:keyword xml:lang="eng">Management plan</dcat:keyword>
+      <dcat:keyword xml:lang="fre">Plan de gestion</dcat:keyword>
+      <dcat:keyword xml:lang="eng">Well</dcat:keyword>
+      fre is missing. Empty field is available.
+      <dcat:keyword xml:lang="spa">Cuenca</dcat:keyword>
+      main language eng is missing and spa not declared has other language. This is not supported.
+
+      To retrieve multilingual element by group we assume that an
+      element in the main language is defined and then
+      we collect element by group.
+      -->
+      <xsl:variable name="numberOfElementWithMainLanguage"
+                    select="count(preceding-sibling::*[name() = $name and @xml:lang = $metadataLanguage])"/>
+      <xsl:variable name="elementId"
+                    select="generate-id()"/>
+      <xsl:variable name="translations"
+                    select="following-sibling::*[
+                                name() = $name
+                                and @xml:lang != $metadataLanguage
+                                and count(preceding-sibling::*[name() = $name and @xml:lang = $metadataLanguage]) = ($numberOfElementWithMainLanguage + 1)]"/>
+      <xsl:variable name="hasTranslations"
+                    select="count($translations) > 0"/>
+      <!-- Skip following siblings -->
+
+      <xsl:variable name="values">
+        <xsl:if test="$isMultilingualElement">
+          <values>
+            <xsl:for-each select="$metadataOtherLanguages/lang">
+              <xsl:variable name="code" select="@code"/>
+              <xsl:variable name="currentLanguageId" select="@id"/>
+              <xsl:variable name="translation"
+                            select="$translations[@xml:lang = $code]"/>
+
+              <!-- TODO: non existing element ? lang_{@code}_
+              Should not happen. Update fixed info create empty element
+              if required for all languages. -->
+              <xsl:variable name="refForExistingElement"
+                            select="if (@code = $metadataLanguage)
+                                    then $ref
+                                    else $translation/gn:element/@ref"/>
+              <value ref="{$refForExistingElement}"
+                     lang="{upper-case(@code)}">
+                <xsl:value-of select="if (@code = $metadataLanguage)
+                                      then $theElement/text()
+                                      else $translation/text()"/>
+              </value>
+            </xsl:for-each>
+          </values>
+        </xsl:if>
+      </xsl:variable>
+
+      <xsl:message><xsl:value-of select="name()"/> (<xsl:value-of select="$isMultilingualElement"/>)
+        values: <xsl:copy-of select="$values"/></xsl:message>
+
+      <!-- Add view and edit template-->
+      <xsl:variable name="contextXpath" select="gn-fn-metadata:getXPath(.)"/>
+      <xsl:variable name="fieldNode" select="$editorConfig/editor/fields/for[@name = $name and @templateModeOnly and (not(@xpath) or @xpath = $contextXpath)]"/>
+
+      <xsl:variable name="isDisabled" select="
+            (name(.) = 'dct:identifier' and count(preceding-sibling::*[name(.) = 'dct:identifier']) = 0 and name(..) = ('dcat:Dataset', 'dcat:DataService')) or
+            (name(..) = 'dcat:Distribution' and name(.) = ('dct:identifier')) or
+            (name(..) = 'dcat:CatalogRecord') or
+            (name(../../..) = 'dcat:CatalogRecord' and name(..) = 'dct:Standard')"/>
+
+      <xsl:choose>
+        <xsl:when test="count($fieldNode/*)>0 and $fieldNode/@templateModeOnly and not($isDisabled)">
+          <xsl:variable name="del" select="'.'"/>
+          <xsl:variable name="template" select="$fieldNode/template"/>
+          <xsl:variable name="currentNode" select="." />
+          <xsl:variable name="readonly">
+            <xsl:choose>
+              <xsl:when test="$template/values/@readonlyIf">
+                <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
+                  <xsl:with-param name="base" select="$currentNode"/>
+                  <xsl:with-param name="in" select="concat('/', $template/values/@readonlyIf)"/>
+                </saxon:call-template>
+              </xsl:when>
+            </xsl:choose>
+          </xsl:variable>
+
+          <xsl:variable name="templateCombinedWithNode" as="node()">
+            <template>
+              <xsl:copy-of select="$template/values"/>
+              <snippet>
+                <xsl:apply-templates mode="gn-merge" select="$template/snippet/*|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet/*">
+                  <xsl:with-param name="node-to-merge" select="$currentNode"/>
+                </xsl:apply-templates>
+              </snippet>
+            </template>
+          </xsl:variable>
+
+          <xsl:variable name="keyValues">
+            <xsl:call-template name="build-key-value-configuration">
+              <xsl:with-param name="template" select="$template"/>
+              <xsl:with-param name="currentNode" select="$currentNode"/>
+              <xsl:with-param name="readonly" select="$readonly"/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <xsl:variable name="originalNode"
+                        select="gn-fn-metadata:getOriginalNode($metadata, .)"/>
+
+          <xsl:variable name="refToDelete">
+            <xsl:call-template name="get-ref-element-to-delete">
+              <xsl:with-param name="node" select="$originalNode"/>
+              <xsl:with-param name="delXpath" select="$del"/>
+            </xsl:call-template>
+          </xsl:variable>
+
+
+          <!-- If the element exist, use the _X<ref> mode which
+                insert the snippet for the element if not use the
+                XPATH mode which will create the new element at the
+                correct location. -->
+          <xsl:variable name="id" select="concat('_X', gn:element/@ref, '_replace')"/>
+          <xsl:call-template name="render-element-template-field">
+            <xsl:with-param name="name" select="$labelConfig/label"/>
+            <!--xsl:with-param name="name" select="$strings/*[name() = $name]" /-->
+            <xsl:with-param name="btnLabel" select="$labelConfig/btnLabel"/>
+            <xsl:with-param name="id" select="$id"/>
+            <xsl:with-param name="isExisting" select="true()"/>
+            <xsl:with-param name="template" select="$templateCombinedWithNode"/>
+            <xsl:with-param name="keyValues" select="$keyValues"/>
+            <xsl:with-param name="refToDelete" select="$refToDelete/gn:element"/>
           </xsl:call-template>
-        </xsl:variable>
-
-        <xsl:variable name="originalNode"
-                      select="gn-fn-metadata:getOriginalNode($metadata, .)"/>
-
-        <xsl:variable name="refToDelete">
-          <xsl:call-template name="get-ref-element-to-delete">
-            <xsl:with-param name="node" select="$originalNode"/>
-            <xsl:with-param name="delXpath" select="$del"/>
-          </xsl:call-template>
-        </xsl:variable>
-
-
-        <!-- If the element exist, use the _X<ref> mode which
-              insert the snippet for the element if not use the
-              XPATH mode which will create the new element at the
-              correct location. -->
-        <xsl:variable name="id" select="concat('_X', gn:element/@ref, '_replace')"/>
-        <xsl:call-template name="render-element-template-field">
-          <xsl:with-param name="name" select="$labelConfig/label"/>
-          <!--xsl:with-param name="name" select="$strings/*[name() = $name]" /-->
-          <xsl:with-param name="btnLabel" select="$labelConfig/btnLabel"/>
-          <xsl:with-param name="id" select="$id"/>
-          <xsl:with-param name="isExisting" select="true()"/>
-          <xsl:with-param name="template" select="$templateCombinedWithNode"/>
-          <xsl:with-param name="keyValues" select="$keyValues"/>
-          <xsl:with-param name="refToDelete" select="$refToDelete/gn:element"/>
-        </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
-        <xsl:variable name="renderedElement">
-          <xsl:call-template name="render-element">
-            <xsl:with-param name="label" select="$labelConfig"/>
-            <xsl:with-param name="value" select="."/>
-            <xsl:with-param name="cls" select="local-name()"/>
-            <xsl:with-param name="xpath" select="$xpath"/>
-            <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
-            <xsl:with-param name="name" select="if ($isEditing) then $ref else ''"/>
-            <xsl:with-param name="editInfo" select="if ($refToDelete) then $refToDelete else gn:element"/>
-            <xsl:with-param name="parentEditInfo" select="if ($added) then $container/gn:element else element()"/>
-            <xsl:with-param name="listOfValues" select="$helper"/>
-            <!-- When adding an element, the element container contains
-            information about cardinality. -->
-            <xsl:with-param name="isFirst"
-                            select="if ($added) then
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+          <xsl:variable name="renderedElement">
+            <xsl:call-template name="render-element">
+              <xsl:with-param name="label" select="$labelConfig"/>
+              <xsl:with-param name="value" select="if ($isMultilingualElement) then $values else ."/>
+              <xsl:with-param name="cls" select="local-name()"/>
+              <xsl:with-param name="xpath" select="$xpath"/>
+              <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
+              <xsl:with-param name="name" select="if ($isEditing) then $ref else ''"/>
+              <xsl:with-param name="editInfo" select="if ($refToDelete) then $refToDelete else gn:element"/>
+              <xsl:with-param name="parentEditInfo" select="if ($added) then $container/gn:element else element()"/>
+              <xsl:with-param name="listOfValues" select="$helper"/>
+              <xsl:with-param name="toggleLang" select="$isMultilingualElementExpanded"/>
+              <!-- When adding an element, the element container contains
+              information about cardinality. -->
+              <xsl:with-param name="isFirst"
+                              select="if ($added) then
                             ($container/gn:element/@down = 'true' and not($container/gn:element/@up)) or
                             (not($container/gn:element/@down) and not($container/gn:element/@up))
                           else
                             (gn:element/@down = 'true' and not(gn:element/@up)) or
                             (not(gn:element/@down) and not(gn:element/@up))"/>
-            <xsl:with-param name="isDisabled" select="$isDisabled"/>
-          </xsl:call-template>
-        </xsl:variable>
+              <xsl:with-param name="isDisabled" select="$isDisabled"/>
+            </xsl:call-template>
+          </xsl:variable>
 
-        <xsl:variable name="renderedAttribute">
-          <xsl:if test="$isEditing">
-            <!-- Render attributes as fields and overwrite the normal behavior -->
-            <xsl:apply-templates mode="render-for-field-for-attribute-dcat-ap" select="@*|gn:attribute[not(@name = parent::node()/@*/name())]">
-              <xsl:with-param name="ref" select="gn:element/@ref"/>
-            </xsl:apply-templates>
-          </xsl:if>
-        </xsl:variable>
+          <xsl:variable name="renderedAttribute">
+            <xsl:if test="$isEditing">
+              <!-- Render attributes as fields and overwrite the normal behavior -->
+              <xsl:apply-templates mode="render-for-field-for-attribute-dcat-ap" select="@*|gn:attribute[not(@name = parent::node()/@*/name())]">
+                <xsl:with-param name="ref" select="gn:element/@ref"/>
+              </xsl:apply-templates>
+            </xsl:if>
+          </xsl:variable>
 
-        <xsl:for-each select="$renderedElement/*">
-          <xsl:copy copy-namespaces="no">
-            <xsl:copy-of select="@*"/>
-            <xsl:copy-of select="*"/>
-            <xsl:copy-of select="$renderedAttribute"/>
-          </xsl:copy>
-        </xsl:for-each>
-      </xsl:otherwise>
-    </xsl:choose>
+          <xsl:for-each select="$renderedElement/*">
+            <xsl:copy copy-namespaces="no">
+              <xsl:copy-of select="@*"/>
+              <xsl:copy-of select="*"/>
+              <xsl:copy-of select="$renderedAttribute"/>
+            </xsl:copy>
+          </xsl:for-each>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
   </xsl:template>
 
   <!-- Hide from the editor in default view -->
@@ -341,7 +450,7 @@
                           $isFlatMode]" />
 
   <!-- Ignore the following attributes in flatMode -->
-  <xsl:template mode="render-for-field-for-attribute-dcat-ap" match="@*[$isFlatMode and name() != 'rdf:about']|@gn:xsderror|@gn:addedObj" priority="101"/>
+  <xsl:template mode="render-for-field-for-attribute-dcat-ap" match="@*[$isFlatMode and name() != 'rdf:about']|@xml:lang|@gn:xsderror|@gn:addedObj" priority="101"/>
 
   <xsl:template mode="render-for-field-for-attribute-dcat-ap" match="@*" priority="100">
     <xsl:variable name="attributeName" select="name(.)"/>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -90,6 +90,7 @@
         <!-- TODO: add xpath and isoType to get label ? -->
         <xsl:with-param name="label" select="$labelConfig/label"/>
         <xsl:with-param name="btnLabel" select="$labelConfig/btnLabel"/>
+        <xsl:with-param name="btnClass" select="if ($labelConfig/btnClass) then $labelConfig/btnClass else ''"/>
         <xsl:with-param name="directive" select="$directive"/>
         <xsl:with-param name="childEditInfo" select="."/>
         <xsl:with-param name="parentEditInfo" select="../gn:element"/>
@@ -306,9 +307,6 @@
         </xsl:if>
       </xsl:variable>
 
-      <xsl:message><xsl:value-of select="name()"/> (<xsl:value-of select="$isMultilingualElement"/>)
-        values: <xsl:copy-of select="$values"/></xsl:message>
-
       <!-- Add view and edit template-->
       <xsl:variable name="contextXpath" select="gn-fn-metadata:getXPath(.)"/>
       <xsl:variable name="fieldNode" select="$editorConfig/editor/fields/for[@name = $name and @templateModeOnly and (not(@xpath) or @xpath = $contextXpath)]"/>
@@ -374,11 +372,13 @@
             <xsl:with-param name="name" select="$labelConfig/label"/>
             <!--xsl:with-param name="name" select="$strings/*[name() = $name]" /-->
             <xsl:with-param name="btnLabel" select="$labelConfig/btnLabel"/>
+            <xsl:with-param name="btnClass" select="if ($labelConfig/btnClass) then $labelConfig/btnClass else ''"/>
             <xsl:with-param name="id" select="$id"/>
             <xsl:with-param name="isExisting" select="true()"/>
             <xsl:with-param name="template" select="$templateCombinedWithNode"/>
             <xsl:with-param name="keyValues" select="$keyValues"/>
             <xsl:with-param name="refToDelete" select="$refToDelete/gn:element"/>
+            <xsl:with-param name="isFirst" select="count(preceding-sibling::*[name() = $name]) = 0"/>
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -62,7 +62,6 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
 
-
     <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
     <xsl:variable name="xpath">
       <xsl:choose>
@@ -190,6 +189,7 @@
                           contains(. , 'resources.get') or
                           contains(., 'file.disclaimer'))]" />
 
+
   <!-- the other elements in DC. -->
   <xsl:template mode="mode-dcat-ap" priority="100" match="dc:*|dct:*|dcat:*|vcard:*|foaf:*|spdx:*|adms:*|owl:*|schema:*|skos:*|mdcat:*">
     <xsl:param name="schema" select="$schema" required="no"/>
@@ -212,7 +212,7 @@
 
     <!-- Skip translations. update-fixed-info takes care of having
     at least one element define in the main language. -->
-    <xsl:if test="not(@xml:lang) or $elementLang = $metadataLanguage">
+    <xsl:if test="not(@xml:lang) or $elementLang = ('', $metadataLanguage)">
 
       <xsl:variable name="name" select="name(.)"/>
       <xsl:variable name="ref" select="gn:element/@ref"/>

--- a/src/main/plugin/dcat-ap/layout/layout.xsl
+++ b/src/main/plugin/dcat-ap/layout/layout.xsl
@@ -212,7 +212,9 @@
 
     <!-- Skip translations. update-fixed-info takes care of having
     at least one element define in the main language. -->
-    <xsl:if test="not(@xml:lang) or $elementLang = ('', $metadataLanguage)">
+    <xsl:if test="$metadataLanguage = ''
+                         or not(@xml:lang)
+                         or $elementLang = ('', $metadataLanguage)">
 
       <xsl:variable name="name" select="name(.)"/>
       <xsl:variable name="ref" select="gn:element/@ref"/>

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -23,10 +23,11 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-        xmlns:dct="http://purl.org/dc/terms/"
-        xmlns:dcat="http://www.w3.org/ns/dcat#"
-        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xslutil="java:org.fao.geonet.util.XslUtil"
                 version="2.0"
                 exclude-result-prefixes="#all">
@@ -70,7 +71,7 @@
         <xsl:if test="$languageCode != ''">
           <lang>
             <xsl:value-of
-              select="concat('&quot;', $languageCode, '&quot;:&quot;#', upper-case($languageCode), '&quot;')"/>
+              select="concat('&quot;', xslutil:threeCharLangCode($languageCode), '&quot;:&quot;#', upper-case($languageCode), '&quot;')"/>
           </lang>
         </xsl:if>
       </xsl:for-each>
@@ -92,7 +93,7 @@
           </xsl:variable>
 
           <xsl:if test="$languageCode != ''">
-            <lang id="{upper-case($languageCode)}" code="{xslutil:twoCharLangCode($languageCode)}">
+            <lang id="{xslutil:threeCharLangCode($languageCode)}" code="{xslutil:twoCharLangCode($languageCode)}">
               <xsl:if test="position() = 1">
                 <xsl:attribute name="default" select="''"/>
               </xsl:if>
@@ -104,7 +105,7 @@
         <xsl:variable name="mainLanguage">
           <xsl:call-template name="get-dcat-ap-language"/>
         </xsl:variable>
-        <lang id="{upper-case($mainLanguage)}" code="{xslutil:twoCharLangCode($mainLanguage)}" default=""/>
+        <lang id="{xslutil:threeCharLangCode($mainLanguage)}" code="{xslutil:twoCharLangCode($mainLanguage)}" default=""/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
+++ b/src/main/plugin/dcat-ap/layout/utility-tpl-multilingual.xsl
@@ -35,7 +35,7 @@
   <!-- Get the main metadata languages -->
   <xsl:template name="get-dcat-ap-language">
     <xsl:param name="languageIri"
-               select="$metadata//dcat:CatalogRecord/dct:language[1]/(@rdf:resource, skos:Concept/@rdf:about)"
+               select="$metadata//dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)"
                required="no"/>
 
     <xsl:variable name="languageCode"
@@ -64,7 +64,7 @@
         <xsl:variable name="languageCode">
           <xsl:call-template name="get-dcat-ap-language">
             <xsl:with-param name="languageIri"
-                            select="(@rdf:resource, skos:Concept/@rdf:about)[1]"/>
+                            select="(@rdf:resource, skos:Concept/@rdf:about, dct:LinguisticSystem/@rdf:about)[1]"/>
           </xsl:call-template>
         </xsl:variable>
 

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-dataset.xml
@@ -19,6 +19,12 @@
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
+        <dct:language>
+          <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          </skos:Concept>
+        </dct:language>
       </dcat:CatalogRecord>
     </dcat:record>
     <dcat:dataset>

--- a/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
+++ b/src/main/plugin/dcat-ap/templates/dcat-ap-vl-service.xml
@@ -19,6 +19,12 @@
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
+        <dct:language>
+          <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          </skos:Concept>
+        </dct:language>
       </dcat:CatalogRecord>
     </dcat:record>
     <dcat:service>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-dataset.xml
@@ -18,6 +18,12 @@
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
+        <dct:language>
+          <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          </skos:Concept>
+        </dct:language>
       </dcat:CatalogRecord>
     </dcat:record>
     <dcat:dataset>

--- a/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
+++ b/src/main/plugin/dcat-ap/templates/metadata-dcat-service.xml
@@ -18,6 +18,12 @@
             <owl:versionInfo>2.0</owl:versionInfo>
           </dct:Standard>
         </dct:conformsTo>
+        <dct:language>
+          <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          </skos:Concept>
+        </dct:language>
       </dcat:CatalogRecord>
     </dcat:record>
     <dcat:service>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -225,17 +225,15 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- ================================================================= -->
-
   <xsl:template match="dcat:Catalog" priority="10">
     <dcat:Catalog>
       <xsl:attribute name="rdf:about">
-        <xsl:value-of select="concat($resourcePrefix,'/catalogs/',$env/system/site/siteId)"/>
+        <xsl:value-of select="concat($resourcePrefix, '/catalogs/', $env/system/site/siteId)"/>
       </xsl:attribute>
-      <dct:title xml:lang="nl">
+      <dct:title xml:lang="{$mainLanguage}">
         <xsl:value-of select="concat('Open Data Catalogus van ', $env/system/site/organization)"/>
       </dct:title>
-      <dct:description xml:lang="nl">
+      <dct:description xml:lang="{$mainLanguage}">
         <xsl:value-of select="concat('Deze catalogus bevat datasets ontsloten door ', $env/system/site/organization)"/>
       </dct:description>
       <dct:identifier>
@@ -244,12 +242,12 @@
       <dct:publisher>
         <!-- Organization in charge of the catalogue defined in the administration > system configuration -->
         <foaf:Agent rdf:about="{$resourcePrefix}/organizations/{encode-for-uri($env/system/site/organization)}">
-          <foaf:name xml:lang="nl">
+          <foaf:name xml:lang="{$mainLanguage}">
             <xsl:value-of select="$env/system/site/organization"/>
           </foaf:name>
           <dct:type>
             <skos:Concept rdf:about="http://purl.org/adms/publishertype/LocalAuthority">
-              <skos:prefLabel xml:lang="nl">Lokaal bestuur</skos:prefLabel>
+              <skos:prefLabel xml:lang="{$mainLanguage}">Lokaal bestuur</skos:prefLabel>
               <skos:prefLabel xml:lang="en">Local Authority</skos:prefLabel>
               <skos:prefLabel xml:lang="fr">Local Authority</skos:prefLabel>
               <skos:prefLabel xml:lang="de">Local Authority</skos:prefLabel>
@@ -263,29 +261,29 @@
           <xsl:if test="normalize-space($serviceUrl) != ''">
             <xsl:attribute name="rdf:about" select="$serviceUrl"/>
           </xsl:if>
-          <foaf:name xml:lang="nl"><xsl:value-of select="$env/system/site/name"/></foaf:name>
+          <foaf:name xml:lang="{$mainLanguage}"><xsl:value-of select="$env/system/site/name"/></foaf:name>
         </foaf:Document>
       </foaf:homepage>
       <dct:license>
         <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0">
           <dct:type>
             <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
-              <skos:prefLabel xml:lang="nl">Werk in het publiek domein</skos:prefLabel>
+              <skos:prefLabel xml:lang="{$mainLanguage}">Werk in het publiek domein</skos:prefLabel>
               <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
               <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
               <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
               <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
             </skos:Concept>
           </dct:type>
-          <dct:title xml:lang="nl">Creative Commons Zero verklaring</dct:title>
-          <dct:description xml:lang="nl">De instantie doet afstand van haar intellectuele eigendomsrechten voor zover dit wettelijk mogelijk is. Hierdoor kan de gebruiker de data hergebruiken voor eender welk doel, zonder een verplichting op naamsvermelding. Deze is de welbekende CC0 licentie.</dct:description>
+          <dct:title xml:lang="{$mainLanguage}">Creative Commons Zero verklaring</dct:title>
+          <dct:description xml:lang="{$mainLanguage}">De instantie doet afstand van haar intellectuele eigendomsrechten voor zover dit wettelijk mogelijk is. Hierdoor kan de gebruiker de data hergebruiken voor eender welk doel, zonder een verplichting op naamsvermelding. Deze is de welbekende CC0 licentie.</dct:description>
           <dct:identifier>https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0</dct:identifier>
         </dct:LicenseDocument>
       </dct:license>
       <dct:language>
         <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
           <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
-          <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
+          <skos:prefLabel xml:lang="{$mainLanguage}">Nederlands</skos:prefLabel>
           <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
           <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
           <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
@@ -514,11 +512,20 @@
                        dct:language|dcat:Dataset/dct:type|dcat:DataService/dct:type|dct:format|dcat:mediaType|adms:status|
                        dct:LicenseDocument/dct:type|dct:accessRights|mdcat:levensfase|mdcat:ontwikkelingstoestand|
                        dcat:compressFormat|dcat:packageFormat" priority="10">
-    <xsl:if test="count(skos:Concept) = 1">
-      <xsl:copy copy-namespaces="no">
-        <xsl:apply-templates select="skos:Concept"/>
-      </xsl:copy>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="count(skos:Concept) = 1">
+        <xsl:copy copy-namespaces="no">
+          <xsl:apply-templates select="skos:Concept"/>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:copy-of select="@*"/>
+          <xsl:apply-templates select="*"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+
   </xsl:template>
 
   <!-- Rename dct:subject -->
@@ -663,7 +670,7 @@
         <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03">
           <dct:identifier>https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2019-10-03</dct:identifier>
           <dct:title>Dcat-ap-vl</dct:title>
-          <dct:description xml:lang="nl">Dit applicatieprofiel beschrijft Open Data Catalogi in Vlaanderen. DCAT-AP Vlaanderen (DCAT-AP VL) is een verdere specialisatie van DCAT-AP. De applicatie waarop dit profiel betrekking heeft is een Open Data Portaal in Vlaanderen. Open Data portalen zijn catalogussen van Open Data datasets. Ze hebben als belangrijkste doelstelling het vindbaar maken van data en hierdoor het hergebruik ervan te stimuleren. Open Data portalen vervullen een centrale rol in de overheidsopdracht om de toegankelijkheid tot overheidsinformatie te realiseren. Met dit applicatieprofiel bevorderen we de uniformiteit van de beschikbare informatie over datasets. Tevens vereenvoudigen we het aggregatie proces van meerdere Open Data Catalogi. Dit document bevat de verplichte elementen en bijkomende elementen waarover DCAT-AP Vlaanderen een uitspraak doet. Aanbevolen en optionele informatie waarvoor geen bijkomende afspraken in de context van DCAT-AP Vlaanderen zijn, zijn niet opgenomen in dit document. Hiervoor verwijzen we naar de DCAT-AP specificatie zelf.</dct:description>
+          <dct:description xml:lang="{$mainLanguage}">Dit applicatieprofiel beschrijft Open Data Catalogi in Vlaanderen. DCAT-AP Vlaanderen (DCAT-AP VL) is een verdere specialisatie van DCAT-AP. De applicatie waarop dit profiel betrekking heeft is een Open Data Portaal in Vlaanderen. Open Data portalen zijn catalogussen van Open Data datasets. Ze hebben als belangrijkste doelstelling het vindbaar maken van data en hierdoor het hergebruik ervan te stimuleren. Open Data portalen vervullen een centrale rol in de overheidsopdracht om de toegankelijkheid tot overheidsinformatie te realiseren. Met dit applicatieprofiel bevorderen we de uniformiteit van de beschikbare informatie over datasets. Tevens vereenvoudigen we het aggregatie proces van meerdere Open Data Catalogi. Dit document bevat de verplichte elementen en bijkomende elementen waarover DCAT-AP Vlaanderen een uitspraak doet. Aanbevolen en optionele informatie waarvoor geen bijkomende afspraken in de context van DCAT-AP Vlaanderen zijn, zijn niet opgenomen in dit document. Hiervoor verwijzen we naar de DCAT-AP specificatie zelf.</dct:description>
           <owl:versionInfo>2.0</owl:versionInfo>
         </dct:Standard>
       </xsl:when>
@@ -675,7 +682,7 @@
         <dct:Standard rdf:about="https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22">
           <dct:identifier>https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22</dct:identifier>
           <dct:title>Metadata-dcat</dct:title>
-          <dct:description xml:lang="nl">Het applicatieprofiel “metadata dcat”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
+          <dct:description xml:lang="{$mainLanguage}">Het applicatieprofiel “metadata dcat”. Dit is een applicatieprofiel gebaseerd op DCAT en richt zich op het verzamelen van informatie over generieke datasets, distributies en services die door een overheid beschikbaar gesteld worden. De datasets en services omvatten zowel publiek toegankelijke als afgeschermde data en diensten (ontwikkeld in en voor eender welk technisch perspectief). Het samenbrengen van al deze informatie in een catalogus laat toe om de vindbaarheid van deze datasets en services te verhogen. Dit applicatieprofiel is het generieke basisprofiel. Afgeleide profielen kunnen zeker aangemaakt worden voor specifieke domeinen of communities. Bijvoorbeeld is DCAT-AP-VL zo’n afgeleid applicatieprofiel, specifiek voor het Open data domein en bijhorende community.</dct:description>
           <owl:versionInfo>2.0</owl:versionInfo>
         </dct:Standard>
       </xsl:when>
@@ -744,7 +751,7 @@
           <xsl:when test="name() = 'dcat:Dataset'">
             <mdcat:statuut>
               <skos:Concept rdf:about="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATA">
-                <skos:prefLabel xml:lang="nl">Vlaamse Open data</skos:prefLabel>
+                <skos:prefLabel xml:lang="{$mainLanguage}">Vlaamse Open data</skos:prefLabel>
                 <skos:prefLabel xml:lang="en">Vlaamse Open data</skos:prefLabel>
                 <skos:prefLabel xml:lang="fr">Vlaamse Open data</skos:prefLabel>
                 <skos:prefLabel xml:lang="de">Vlaamse Open data</skos:prefLabel>
@@ -755,7 +762,7 @@
           <xsl:otherwise>
             <mdcat:statuut>
               <skos:Concept rdf:about="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATASERVICE">
-                <skos:prefLabel xml:lang="nl">Vlaamse Open data Service</skos:prefLabel>
+                <skos:prefLabel xml:lang="{$mainLanguage}">Vlaamse Open data Service</skos:prefLabel>
                 <skos:prefLabel xml:lang="en">Vlaamse Open data Service</skos:prefLabel>
                 <skos:prefLabel xml:lang="fr">Vlaamse Open data Service</skos:prefLabel>
                 <skos:prefLabel xml:lang="de">Vlaamse Open data Service</skos:prefLabel>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -189,6 +189,8 @@
     <xsl:variable name="followingSiblings"
                   select="following-sibling::*[name() = $name]"/>
 
+    <xsl:message>building <xsl:value-of select="name()"/> </xsl:message>
+    <xsl:message>building <xsl:copy-of select="$locales"/> </xsl:message>
     <!-- Select element with same name and different xml:lang attribute
     until the next one with the main language. -->
     <xsl:variable name="currentGroup"

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -135,8 +135,8 @@
   eg. when clicking + -->
   <xsl:template match="*[name() = $multilingualElements
                          and $isMultilingual
-                         and not(@xml:lang)]"
-                        priority="100">
+                         and (not(@xml:lang) or not(string(@xml:lang)))]"
+                        priority="105">
     <xsl:variable name="name"
                   select="name()"/>
     <xsl:variable name="value"

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -247,10 +247,9 @@
           </foaf:name>
           <dct:type>
             <skos:Concept rdf:about="http://purl.org/adms/publishertype/LocalAuthority">
-              <skos:prefLabel xml:lang="{$mainLanguage}">Lokaal bestuur</skos:prefLabel>
-              <skos:prefLabel xml:lang="en">Local Authority</skos:prefLabel>
-              <skos:prefLabel xml:lang="fr">Local Authority</skos:prefLabel>
-              <skos:prefLabel xml:lang="de">Local Authority</skos:prefLabel>
+              <xsl:for-each select="$locales/lang/@code">
+                <skos:prefLabel xml:lang="{.}">Lokaal bestuur</skos:prefLabel>
+              </xsl:for-each>
               <skos:inScheme rdf:resource="http://purl.org/adms/publishertype/1.0"/>
             </skos:Concept>
           </dct:type>
@@ -268,10 +267,9 @@
         <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0">
           <dct:type>
             <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
-              <skos:prefLabel xml:lang="{$mainLanguage}">Werk in het publiek domein</skos:prefLabel>
-              <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
-              <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
-              <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
+              <xsl:for-each select="$locales/lang/@code">
+                <skos:prefLabel xml:lang="{.}">Werk in het publiek domein</skos:prefLabel>
+              </xsl:for-each>
               <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
             </skos:Concept>
           </dct:type>
@@ -283,10 +281,9 @@
       <dct:language>
         <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
           <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
-          <skos:prefLabel xml:lang="{$mainLanguage}">Nederlands</skos:prefLabel>
-          <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
-          <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
-          <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
+          <xsl:for-each select="$locales/lang/@code">
+            <skos:prefLabel xml:lang="{.}">Nederlands</skos:prefLabel>
+          </xsl:for-each>
           <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
         </skos:Concept>
       </dct:language>
@@ -490,22 +487,6 @@
       <xsl:apply-templates select="adms:identifier"/>
     </dcat:Distribution>
   </xsl:template>
-
-  <!-- =================================================================  -->
-
-  <!-- Set default xml:lang value when missing
-  <xsl:template match="dcat:Dataset/dct:title|dcat:DataService/dct:title|dcat:Dataset/dct:description|
-                       dcat:DataService/dct:description|dcat:Distribution/dct:title|
-                       dcat:Distribution/dct:description|foaf:Agent/foaf:name|dcat:keyword"
-                priority="10">
-    <xsl:copy copy-namespaces="no">
-      <xsl:apply-templates select="@*"/>
-      <xsl:if test="not(@xml:lang)">
-        <xsl:attribute name="xml:lang">nl</xsl:attribute>
-      </xsl:if>
-      <xsl:value-of select="."/>
-    </xsl:copy>
-  </xsl:template> -->
 
   <!-- Remove empty concepts -->
   <xsl:template match="foaf:Agent/dct:type|mdcat:MAGDA-categorie|mdcat:statuut|dcat:theme|dct:accrualPeriodicity|
@@ -751,10 +732,9 @@
           <xsl:when test="name() = 'dcat:Dataset'">
             <mdcat:statuut>
               <skos:Concept rdf:about="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATA">
-                <skos:prefLabel xml:lang="{$mainLanguage}">Vlaamse Open data</skos:prefLabel>
-                <skos:prefLabel xml:lang="en">Vlaamse Open data</skos:prefLabel>
-                <skos:prefLabel xml:lang="fr">Vlaamse Open data</skos:prefLabel>
-                <skos:prefLabel xml:lang="de">Vlaamse Open data</skos:prefLabel>
+                <xsl:for-each select="$locales/lang/@code">
+                  <skos:prefLabel xml:lang="{.}">Vlaamse Open data</skos:prefLabel>
+                </xsl:for-each>
                 <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
               </skos:Concept>
             </mdcat:statuut>
@@ -762,10 +742,9 @@
           <xsl:otherwise>
             <mdcat:statuut>
               <skos:Concept rdf:about="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATASERVICE">
-                <skos:prefLabel xml:lang="{$mainLanguage}">Vlaamse Open data Service</skos:prefLabel>
-                <skos:prefLabel xml:lang="en">Vlaamse Open data Service</skos:prefLabel>
-                <skos:prefLabel xml:lang="fr">Vlaamse Open data Service</skos:prefLabel>
-                <skos:prefLabel xml:lang="de">Vlaamse Open data Service</skos:prefLabel>
+                <xsl:for-each select="$locales/lang/@code">
+                  <skos:prefLabel xml:lang="{.}">Vlaamse Open data Service</skos:prefLabel>
+                </xsl:for-each>
                 <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden"/>
               </skos:Concept>
             </mdcat:statuut>

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -72,6 +72,9 @@
   <xsl:variable name="isMultilingual"
                 select="count($locales/*) > 1"/>
 
+  <xsl:variable name="isLanguageSet"
+                select="count($locales/*) >= 1"/>
+
   <xsl:variable name="editorConfig"
                 select="document('layout/config-editor.xml')"/>
 
@@ -129,17 +132,18 @@
   <!-- Ignore element not in main language (they are handled in dcat2-translations-builder. -->
   <xsl:template match="*[
                           count(*) = 0
-                          and name() != $nonMultilingualElements
-                          and $isMultilingual
+                          and not(name() = $nonMultilingualElements)
+                          and $isLanguageSet
                           and @xml:lang != $mainLanguage]"
-                        priority="100"/>
+                        priority="100">
+  </xsl:template>
 
   <!-- Expand element which may not contain xml:lang attribute
   eg. when clicking + -->
   <xsl:template match="*[
                           count(*) = 0
-                          and name() != $nonMultilingualElements
-                          and $isMultilingual
+                          and not(name() = $nonMultilingualElements)
+                          and $isLanguageSet
                          and (not(@xml:lang) or not(string(@xml:lang)))]"
                         priority="105">
     <xsl:variable name="name"
@@ -158,15 +162,14 @@
 
   <xsl:template match="*[
                           count(*) = 0
-                          and name() != $nonMultilingualElements
-                          and $isMultilingual
+                          and not(name() = $nonMultilingualElements)
+                          and $isLanguageSet
                          and @xml:lang = $mainLanguage]"
                 priority="100">
     <!-- Then we copy translations of following siblings
     or create empty elements. -->
     <xsl:variable name="name"
                   select="name(.)"/>
-
     <xsl:variable name="excluded"
                   select="gn-fn-dcat-ap:isNotMultilingualField(., $editorConfig)"/>
     <xsl:variable name="isMultilingualElement"

--- a/src/main/plugin/dcat-ap/update-fixed-info.xsl
+++ b/src/main/plugin/dcat-ap/update-fixed-info.xsl
@@ -122,19 +122,24 @@
   <xsl:variable name="resourceAbout" select="concat(/root/env/nodeURL, 'resources/', $resourceType, '/', $resourceUUID)"/>
 
   <!-- Multilingual support -->
-  <xsl:variable name="multilingualElements"
-                select="('dct:title', 'dct:description')"/>
+  <xsl:variable name="nonMultilingualElements"
+                select="$editorConfig/editor/multilingualFields/exclude/name"/>
+
 
   <!-- Ignore element not in main language (they are handled in dcat2-translations-builder. -->
-  <xsl:template match="*[name() = $multilingualElements
-                         and $isMultilingual
-                         and @xml:lang != $mainLanguage]"
+  <xsl:template match="*[
+                          count(*) = 0
+                          and name() != $nonMultilingualElements
+                          and $isMultilingual
+                          and @xml:lang != $mainLanguage]"
                         priority="100"/>
 
   <!-- Expand element which may not contain xml:lang attribute
   eg. when clicking + -->
-  <xsl:template match="*[name() = $multilingualElements
-                         and $isMultilingual
+  <xsl:template match="*[
+                          count(*) = 0
+                          and name() != $nonMultilingualElements
+                          and $isMultilingual
                          and (not(@xml:lang) or not(string(@xml:lang)))]"
                         priority="105">
     <xsl:variable name="name"
@@ -151,8 +156,10 @@
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template match="*[name() = $multilingualElements
-                         and $isMultilingual
+  <xsl:template match="*[
+                          count(*) = 0
+                          and name() != $nonMultilingualElements
+                          and $isMultilingual
                          and @xml:lang = $mainLanguage]"
                 priority="100">
     <!-- Then we copy translations of following siblings
@@ -189,8 +196,6 @@
     <xsl:variable name="followingSiblings"
                   select="following-sibling::*[name() = $name]"/>
 
-    <xsl:message>building <xsl:value-of select="name()"/> </xsl:message>
-    <xsl:message>building <xsl:copy-of select="$locales"/> </xsl:message>
     <!-- Select element with same name and different xml:lang attribute
     until the next one with the main language. -->
     <xsl:variable name="currentGroup"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a52e4ac-bdbc-4dd3-be2f-eb5c159f6b51)




* Allowed encoding for languages (`dcat:CatalogRecord/dct:language[1]/(@rdf:resource|skos:Concept/@rdf:about|dct:LinguisticSystem/@rdf:about)`):

```xml
  <dcat:CatalogRecord>
      <dct:language>
        <dct:LinguisticSystem rdf:about="http://publications.europa.eu/resource/authority/language/FRE"/>
      </dct:language>

      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRE"/>
      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/>
      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/NLD"/>

      <dct:language>
         <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/NLD">
            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
            <skos:prefLabel xml:lang="nl">Nederlands</skos:prefLabel>
            <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
            <skos:prefLabel xml:lang="fr">néerlandais</skos:prefLabel>
            <skos:prefLabel xml:lang="de">Niederländisch</skos:prefLabel>
            <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/language"/>
         </skos:Concept>
      </dct:language>
```

* Languages are defined in the catalog record

![image](https://github.com/user-attachments/assets/43c92138-8dfe-442f-b7ed-c3367dfb6e63)


* First language is the main one.

* `@xml:lang` MUST use an ISO 2 letter code


## Questions

* Which code for Nederlands - nl or du ? We have the 2 in various places mapping to do with dut used for UI language > nl
* How to handle multilingual list of license, protocols, default bbox ... ?
* Issue when adding a new element without form reload - xml:lang attribute are not added automatically (it is done in updatefixedinfo) so the form snippet contains element without ref.

## Vlaanderen records consequences

* The language of the record needs to be declared.
* No more hard coded languages (translations added based on declared languages - like ISO)

```xml
        <mdcat:statuut xmlns:mdcat="https://data.vlaanderen.be/ns/metadata-dcat#">
          <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/VLOPENDATA">
            <skos:prefLabel xml:lang="nl">Vlaamse Open data</skos:prefLabel>
            <skos:prefLabel xml:lang="en">Vlaamse Open data</skos:prefLabel>
            <skos:prefLabel xml:lang="fr">Vlaamse Open data</skos:prefLabel>
            <skos:prefLabel xml:lang="de">Vlaamse Open data</skos:prefLabel>
            <skos:inScheme rdf:resource="https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden" />
```


## Editor 

* Added a temporary view to create a full view like the ISO advanced for testing.

![image](https://github.com/user-attachments/assets/dc93ba62-3821-40ad-a644-a34075b06753)


## Core work

* https://github.com/geonetwork/core-geonetwork/pull/8377

